### PR TITLE
fix: form control description typo

### DIFF
--- a/src/content/guidelines/impl/form-control-description.mdx
+++ b/src/content/guidelines/impl/form-control-description.mdx
@@ -33,7 +33,7 @@ import Level from "../../../components/Level.astro";
       ```html
       <div class="form-group">
         <label for="name">名前</label>
-        <input id="name" aria-labelledby="name-description" />
+        <input id="name" aria-describedby="name-description" />
         <p id="name-description">例）山田太郎</p>
       </div>
       ```
@@ -51,7 +51,7 @@ import Level from "../../../components/Level.astro";
       ```html
       <div class="form-group">
         <label for="name">名前</label>
-        <input id="name" aria-labelledby="name-description name-error" />
+        <input id="name" aria-describedby="name-description name-error" />
         <p id="name-description">例）山田太郎</p>
         <p id="name-error">名前を入力してください。</p>
       </div>


### PR DESCRIPTION
## 概要

`form-control-description.mdx` における `aria-describedby` のコード説明部分に typo があったので修正しました。

## 修正内容

- `aria-labelledby` -> `aria-describedby` に修正