### PR TITLE
fix: 動画の字幕に、Making Audio and Video Media Accessibleにリンクする

### DIFF
--- a/src/content/guidelines/design/video-caption.mdx
+++ b/src/content/guidelines/design/video-caption.mdx
@@ -45,4 +45,5 @@ import Level from "../../../components/Level.astro";
 ##### 参考情報
 
 - [達成基準 1.2.2: キャプション (収録済) を理解する](https://waic.jp/translations/WCAG21/Understanding/captions-prerecorded.html)
+- [Making Audio and Video Media Accessible](https://www.w3.org/WAI/media/av/)
 - [字幕を追加する - YouTube ヘルプ](https://support.google.com/youtube/answer/2734796?hl=ja)


### PR DESCRIPTION
close #24 