### PR TITLE
fix: 「リンクテキスト」と「新しいタブで開くリンク」にあった重複を整理する

### DIFF
--- a/src/content/guidelines/design/link-opens-in-new-tab.mdx
+++ b/src/content/guidelines/design/link-opens-in-new-tab.mdx
@@ -12,16 +12,15 @@ import Level from "../../../components/Level.astro";
 #### チェック項目
 
 <Checkpoint title="リンクやフォーム送信を同じタブで開く" />
-<Checkpoint title="新しいタブまたはウィンドウで開く場合、ユーザーに事前に知らせる" />
 
 #### 「{frontmatter.title}」とは
 
 <Level level={frontmatter.level} />
 
-特に視覚的なコンテンツを知覚するのに困難を伴うユーザーをはじめ、ユーザーにとっては、リンクやフォーム送信を新しいタブで開くことは混乱の原因となりえます。
+視覚的なコンテンツを知覚するのに困難を伴うユーザーをはじめとする一部のユーザーにとっては、リンクやフォーム送信を新しいタブで開くことは混乱の原因となりえます。
 
 ##### 参考情報
 
-- [G201: 新しいウィンドウを開くときに、利用者へ事前に知らせる](https://waic.jp/translations/WCAG21/Techniques/general/G201)
 - [達成基準 3.2.1: フォーカス時を理解する](https://waic.jp/translations/WCAG21/Understanding/on-focus.html)
-- [達成基準 3.2.2: 入力時を理解する](https://waic.jp/translations/WCAG21/Understanding/on-input.html)
+- [達成基準 3.2.5: 要求による変化を理解する](https://waic.jp/translations/WCAG21/Understanding/change-on-request)
+- [G200: 必要なときにのみリンク先を新しいウィンドウ及びタブで開く](https://waic.jp/translations/WCAG21/Techniques/general/G200)

--- a/src/content/guidelines/design/link-text.mdx
+++ b/src/content/guidelines/design/link-text.mdx
@@ -26,3 +26,4 @@ import Level from "../../../components/Level.astro";
 ##### 参考情報
 
 - [達成基準 2.4.4: リンクの目的 (コンテキスト内) を理解する](https://waic.jp/translations/WCAG21/Understanding/link-purpose-in-context.html)
+- [G201: 新しいウィンドウを開くときに、利用者へ事前に知らせる](https://waic.jp/translations/WCAG21/Techniques/general/G201)


### PR DESCRIPTION
close #25 