### PR TITLE
feat: 高コントラストメディアの場合に色をクッキリさせる

### DIFF
--- a/src/assets/stylesheets/global.css
+++ b/src/assets/stylesheets/global.css
@@ -110,4 +110,13 @@
       scroll-margin-block: 3rem;
     }
   }
+  
+  @media (prefers-contrast: more) {
+    html {
+      --color-text: #000000;
+      --color-icon: #1f1f1f;
+      --color-dimmed: #1f1f1f;
+      --color-border: #1f1f1f;
+    }
+  }
 }

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -263,5 +263,11 @@ const nav = {
       margin-top: 2.75rem;
       color: #626262;
     }
+
+    @media (prefers-contrast: more) {
+      .nav-content {
+        color: #1f1f1f;
+      }
+    }
   }
 </style>


### PR DESCRIPTION
## Before
![LIFULLアクセシビリティガイドラインの画面キャプチャ](https://github.com/lifull/accessibility-guidelines/assets/490085/a30e0903-0d74-4397-9b79-40ad65c626c1)

## After (`@media (prefers-contrast: more)`)
![LIFULLアクセシビリティガイドラインの画面キャプチャ（ナビゲーションやボーダーの色が濃くなっている）](https://github.com/lifull/accessibility-guidelines/assets/490085/63b35d52-4a92-486f-9cf2-c43dc76d95fd)
