### PR TITLE
add 3.3.8/3.3.9

### DIFF
--- a/src/content/guidelines/impl/allow-copy-paste.mdx
+++ b/src/content/guidelines/impl/allow-copy-paste.mdx
@@ -1,0 +1,28 @@
+---
+area: impl
+category: forms
+level: 2
+title: コピー＆ペーストの許容
+slug: allow-copy-paste
+---
+
+import Checkpoint from "../../../components/Checkpoint.astro";
+import Level from "../../../components/Level.astro";
+
+#### チェック項目
+
+<Checkpoint>
+  {/* prettier-ignore */}
+  <span slot="title">コピー＆ペーストを禁止しない</span>
+</Checkpoint>
+
+#### 「{frontmatter.title}」とは
+
+<Level level={frontmatter.level} />
+
+特定の認知障害を持つユーザーは、ユーザー名とパスワードの記憶に苦労することがあるため、コピー＆ペーストが禁止されているログインフォームなどが利用できないことがあります。
+
+##### 参考情報
+
+- [Understanding Success Criterion 3.3.8: Accessible Authentication](https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum.html)
+- [Understanding Success Criterion 3.3.9: Accessible Authentication](https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-enhanced.html)

--- a/src/content/guidelines/impl/identify-input-purpose.mdx
+++ b/src/content/guidelines/impl/identify-input-purpose.mdx
@@ -28,6 +28,7 @@ import Level from "../../../components/Level.astro";
 <Level level={frontmatter.level} />
 
 `input`要素の`type`属性や`autocomplete`属性を使用して入力フィールドの目的を特定しておくと、目的に応じたソフトウェアキーボードが表示されたり、ブラウザーに保存された値の補完機能を利用できるようになったりします。
+これにより、ログインの時の認知負荷を下げる効果もあります。
 
 <Cases>
   <div slot="title">
@@ -68,3 +69,8 @@ import Level from "../../../components/Level.astro";
     <span slot="title">入力方式を指定するために`inputmode`を用いる。</span>
   </Case>
 </Cases>
+
+##### 参考情報
+
+- [Understanding Success Criterion 3.3.8: Accessible Authentication](https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum.html)
+- [Understanding Success Criterion 3.3.9: Accessible Authentication](https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-enhanced.html)

--- a/src/pages/impl-forms.astro
+++ b/src/pages/impl-forms.astro
@@ -12,6 +12,8 @@ import * as labellessControl from "../content/guidelines/impl/labelless-control.
 // レベル2
 import * as identifyInputPurpose from "../content/guidelines/impl/identify-input-purpose.mdx";
 import * as groupedFormControl from "../content/guidelines/impl/grouped-form-control.mdx";
+import * as allowCopyPaste from "../content/guidelines/impl/allow-copy-paste.mdx";
+
 
 // レベル3
 import * as formControlDescription from "../content/guidelines/impl/form-control-description.mdx";
@@ -35,6 +37,7 @@ import * as formControlDescription from "../content/guidelines/impl/form-control
   <Guidelines level={2}>
     <Guideline guideline={identifyInputPurpose} />
     <Guideline guideline={groupedFormControl} />
+    <Guideline guideline={allowCopyPaste} />
   </Guidelines>
 
   <Guidelines level={3}>


### PR DESCRIPTION
https://github.com/lifull/accessibility-guidelines/issues/63

---

- 実装 >フォーム > 入力項目の特定に追加
  - 内容：ログインの時の認知負荷を下げる効果がある点
  - そのほか：参考ドキュメントの追加

- 実装 >フォーム > コピー＆ペーストの許容を追加
  - レベル：コスト不要で制作事情的な観点もとくに考慮すべき内容はないのでそのままWCAGのAAを反映
  - 内容：特定の認知障害を持つユーザーがログインフォームが利用できないことがある点
  - そのほか：参考ドキュメントの追加