### PR TITLE
update actions/upload-pages-artifact v1->v3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build Project
         run: npm run build
       - name: Upload Pages Artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: "./dist/"
 


### PR DESCRIPTION
内部で使ってるactions/upload-artifact@v3が2025-01末でdeprecatedになってたので